### PR TITLE
영문상위 일 경우

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 * Selenium Web Driver 설치 https://chromedriver.chromium.org/downloads
 * config.json 생성 및 Kidsnote 계정 정보 입력
 
+현재 사용하고 있는 버전을 설치 ChromeDriver 88.0.4324.96
 
 ## 결과 파일
 * 사진 파일

--- a/kidsnote_crawl.py
+++ b/kidsnote_crawl.py
@@ -26,8 +26,12 @@ with open('config.json') as config_file:
 
 options = webdriver.ChromeOptions() # 크롬 옵션 객체 생성
 options.add_argument('headless') # headless 모드 설정
+options.add_argument('lang=ko')
 
+# window
 driver = webdriver.Chrome("./chromedriver.exe", options=options)
+# for mac
+#driver = webdriver.Chrome("./chromedriver", options=options)
 
 
 # config.json의 ID/PW를 통한 로그인


### PR DESCRIPTION
1. 맥일 경우 chromedriver 파일명이 다른 부분 추가

2. 영문 상위 일경우에 브라우저의 날짜를 가져오는게 달라 집니다.
그래서 한글 상위의 chromedriver 를 설정하는 옵션을 추가

> Traceback (most recent call last):
  File "/Users/forteleaf/kidsnote/kidsnote_crawl/./kidsnote_crawl.py", line 126, in <module>
    select_card_and_download(idx)
  File "/Users/forteleaf/kidsnote/kidsnote_crawl/./kidsnote_crawl.py", line 77, in select_card_and_download
    comment_json[get_report_date()] = read_comment()
  File "/Users/forteleaf/kidsnote/kidsnote_crawl/./kidsnote_crawl.py", line 99, in get_report_date
    this_time_t = datetime.datetime.strptime(report_date.strip()[:-4], '%Y년 %m월 %d일')
  File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/local/Cellar/python@3.9/3.9.1_8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data 'Wednesday, February 24, ' does not match format '%Y년 %m월 %d일'
